### PR TITLE
Upload edited image to the provided signed URL

### DIFF
--- a/src/ImageRequest.js
+++ b/src/ImageRequest.js
@@ -30,6 +30,8 @@ class ImageRequest {
     let qp = this._parseQueryParams()
     qp = await this._inferOutputFormatQp(qp)
 
+    this.destUrl = qp.dest || undefined
+
     this.schema = schemaParser.getSchemaForQueryParams(qp)
     this.edits = schemaParser.normalizeAndValidateSchema(this.schema, qp)
     this.headers = this.event.headers

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ exports.handler = async (event, context, callback) => {
     const processedRequest = await imageHandler.process()
 
     const response = {
-      statusCode: 200,
+      statusCode: processedRequest.Body ? 200 : 204,
       headers: getResponseHeaders(processedRequest, null),
       body: processedRequest.Body,
       isBase64Encoded: true


### PR DESCRIPTION
When supplying a `dest` parameter it will try to upload the processed image to that URL:
![Jun-04-2020 21-46-25](https://user-images.githubusercontent.com/1748778/83808679-1cbe2d80-a6ad-11ea-8ba6-ca23f97717f4.gif)

If the destination URL is invalid it will fallback to the original behaviour and return the image bytes:
![Jun-04-2020 21-45-58](https://user-images.githubusercontent.com/1748778/83808594-f7c9ba80-a6ac-11ea-9580-683034504282.gif)

